### PR TITLE
Use Spark hadoop 3.2 bundle

### DIFF
--- a/dev/docker/engine/Dockerfile
+++ b/dev/docker/engine/Dockerfile
@@ -66,7 +66,7 @@ ARG MLSQL_SPARK_VERSION=3.0
 ARG MLSQL_VERSION=2.1.0-SNAPSHOT
 
 ## Setup environment variables
-ENV SPARK_HOME /work/spark-${SPARK_VERSION}-bin-hadoop2.7
+ENV SPARK_HOME /work/spark-${SPARK_VERSION}-bin-hadoop3.2
 ENV BASE_DIR /home/deploy
 ENV MLSQL_HOME ${BASE_DIR}/mlsql
 ENV PATH=$PATH:${MLSQL_HOME}/bin:${SPARK_HOME}/sbin:${SPARK_HOME}/bin:/opt/conda/bin
@@ -76,19 +76,19 @@ RUN mkdir -p /work/logs
 RUN mkdir -p /work/user
 
 ## Spark
-ADD mlsql-sandbox/lib/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz /work
+ADD mlsql-sandbox/lib/spark-${SPARK_VERSION}-bin-hadoop3.2.tgz /work
 COPY mlsql-sandbox/conf/log4j.properties ${SPARK_HOME}/conf/
-
-##  auxiliary jars
-COPY mlsql-sandbox/lib/juicefs-hadoop-0.15.2-linux-amd64.jar /${MLSQL_HOME}/libs/
-COPY mlsql-sandbox/lib/ansj_seg-5.1.6.jar ${MLSQL_HOME}/libs/
-COPY mlsql-sandbox/lib/nlp-lang-1.7.8.jar ${MLSQL_HOME}/libs/
 
 WORKDIR ${BASE_DIR}
 
 ## mlsql
 ADD mlsql-sandbox/lib/"mlsql-engine_${MLSQL_SPARK_VERSION}-${MLSQL_VERSION}.tar.gz" ${BASE_DIR}/
 RUN mv "mlsql-engine_${MLSQL_SPARK_VERSION}-${MLSQL_VERSION}" mlsql
+
+##  auxiliary jars
+COPY mlsql-sandbox/lib/juicefs-hadoop-0.15.2-linux-amd64.jar /${MLSQL_HOME}/libs/
+COPY mlsql-sandbox/lib/ansj_seg-5.1.6.jar ${MLSQL_HOME}/libs/
+COPY mlsql-sandbox/lib/nlp-lang-1.7.8.jar ${MLSQL_HOME}/libs/
 
 COPY engine/entrypoint.sh ${BASE_DIR}/
 

--- a/dev/docker/engine/submit-engine.sh
+++ b/dev/docker/engine/submit-engine.sh
@@ -28,7 +28,7 @@ set -u
 set -e
 set -o pipefail
 
-MLSQL_SPARK_VERSION=${MLSQL_SPARK_VERSION:-2.4}
+MLSQL_SPARK_VERSION=${MLSQL_SPARK_VERSION:-3.0}
 MLSQL_VERSION=${MLSQL_VERSION:-2.1.0-SNAPSHOT}
 
 if [[ ${MLSQL_SPARK_VERSION} = "2.3" || ${MLSQL_SPARK_VERSION} = "2.4" ]]
@@ -42,7 +42,7 @@ else
   exit 1
 fi
 
-container_lib_path="local:///home/deploy/libs/"
+container_lib_path="local:///home/deploy/mlsql/libs/"
 mlsql_jar="${container_lib_path}/streamingpro-mlsql-spark_${MLSQL_SPARK_VERSION}_${scala_version}-${MLSQL_VERSION}.jar"
 auxiliary_jars="${container_lib_path}/juicefs-hadoop-0.15.2-linux-amd64.jar:${container_lib_path}/ansj_seg-5.1.6.jar:${container_lib_path}/nlp-lang-1.7.8.jar"
 K8S_URL=${K8S_URL:-https://localhost:6443}


### PR DESCRIPTION
## What changes are proposed in this PR?
To better support cloud storage, upgrade spark hadoop bundle from 2.7 to 3.2

## How was this PR tested?
By run the MLSQL engine in K8S 

## Spark compatibility
Spark 3.1 OK
Spark 3.x Not supported