### PR TITLE
Use local mysql database in application.docker.yml

### DIFF
--- a/dev/docker/mlsql-sandbox/conf/application.docker.yml
+++ b/dev/docker/mlsql-sandbox/conf/application.docker.yml
@@ -6,7 +6,7 @@ mode:
 production:
   datasources:
     mysql:
-      host: 192.168.50.2
+      host: 127.0.0.1
       port: 3306
       database: mlsql_console
       username: root


### PR DESCRIPTION
## What changes are proposed in this PR?

Use local mysql database in application.docker.yml


## How was this PR tested?
By running sandbox container and manually run tests

## Spark Compatibility
Spark 3.x     OK
Spark 2.4.x  OK